### PR TITLE
Fixes GHC 8.6 - MonadFail issue

### DIFF
--- a/src/Marvin/Interpolate.hs
+++ b/src/Marvin/Interpolate.hs
@@ -104,10 +104,12 @@ evalExprs l = evalState (mapM stitch l) decls
     stitch :: Either a b -> S.State [c] (Either c b)
     stitch (Right str) = return $ Right str
     stitch (Left _) = do
-        (name:rest) <- get
-        put rest
-        return $ Left name
-
+        crs <- get
+        case crs of
+          [] -> error "This should never happen."
+          (name:rest) -> do
+            put rest
+            return $ Left name
 
 -- | Common core of all interpolators.
 --


### PR DESCRIPTION
Closes #2 

See here for more info: https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.6#monadfaildesugaring-by-default
about the motivation.

See here for proposed fixes: https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail#Adaptingoldcode

@JustusAdam This is just a WIP but I figured it would be easier to discuss with a diff on hand. 